### PR TITLE
Decouple scroll event from on_mouse_move to on_scroll

### DIFF
--- a/engine/include/engine/platform/PlatformEventObserver.hpp
+++ b/engine/include/engine/platform/PlatformEventObserver.hpp
@@ -22,6 +22,11 @@ namespace engine::platform {
         virtual void on_mouse_move(MousePosition position) { }
 
         /**
+         * @brief Called by @ref engine::platform::PlatformController for every frame in which the scroll button is moved.
+         */
+        virtual void on_scroll(MousePosition position) {}
+
+        /**
         * @brief Called by @ref engine::platform::PlatformController for every frame in an event occurred on the keyboard or mouse key.
         */
         virtual void on_key(Key key) { }

--- a/engine/src/PlatformController.cpp
+++ b/engine/src/PlatformController.cpp
@@ -215,7 +215,7 @@ namespace engine::platform {
     void PlatformController::_platform_on_scroll(double x, double y) {
         g_mouse_position.scroll = y;
         for (auto &observer: m_platform_event_observers) {
-            observer->on_mouse_move(g_mouse_position);
+            observer->on_scroll(g_mouse_position);
         }
     }
 

--- a/engine/src/PlatformController.cpp
+++ b/engine/src/PlatformController.cpp
@@ -93,6 +93,7 @@ namespace engine::platform {
 
     void PlatformController::poll_events() {
         g_mouse_position.dx = g_mouse_position.dy = 0.0f;
+        g_mouse_position.scroll = 0.0f;
         glfwPollEvents();
         for (int i = 0; i < KEY_COUNT; ++i) {
             update_key(key_ref(static_cast<KeyId>(i)));


### PR DESCRIPTION
`PlatformEventObserver` processes both `mouse moved` and `scroll` in `PlatformEventObserver::on_mouse_moved`. 
This makes the API smaller, but additional logic has to be implemented inside `CustomEventObserver::on_mouse_moved` to distinguish between these two events. 

This PR decouples the scroll event from `PlatformEventObserver::on_mouse_move` to `PlatformEventObserver::on_scroll.` and fixes a bug where `MousePosition::Scroll` wasn't set to 0 at the beginning of each frame.

The `PlatformController` now calls `PlatformEventObserver::on_scroll` when a scroll event happens instead of `PlatformEventObserver::on_mouse_move.`

How to adapt: 
* If there was  code in your  `CustomPlatformEventObserver::on_mouse_move` for processing the scroll event:
  * Implement `CustomPlatformEventObserver::on_scroll`
  * Move the logic for processing the scroll event from `CustomPlatformEventObserver::on_mouse_move` to `CustomPlatformEventObserver::on_scroll`
* No changes needed if your app doesn't use the scroll event