### PR TITLE
[BUGFIX] Support GL_RGBA and GL_RED texture formats for skyboxes.

### DIFF
--- a/engine/src/OpenGL.cpp
+++ b/engine/src/OpenGL.cpp
@@ -152,7 +152,8 @@ uint32_t OpenGL::load_skybox_textures(const std::filesystem::path &path, bool fl
             uint32_t i = face_index(file.path()
                                         .stem()
                                         .c_str());
-            CHECKED_GL_CALL(glTexImage2D, GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RGB, width, height, 0, GL_RGB,
+            int32_t format = texture_format(nr_channels);
+            CHECKED_GL_CALL(glTexImage2D, GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, format, width, height, 0, format,
                             GL_UNSIGNED_BYTE,
                             data);
         } else {

--- a/engine/test/app/resources/shaders/skybox.glsl
+++ b/engine/test/app/resources/shaders/skybox.glsl
@@ -9,9 +9,9 @@ uniform mat4 view;
 
 void main()
 {
-TexCoords = aPos;
-vec4 pos = projection * view * vec4(aPos, 1.0);
-gl_Position = pos.xyww;
+    TexCoords = aPos;
+    vec4 pos = projection * view * vec4(aPos, 1.0);
+    gl_Position = pos.xyww;
 }
 
 //#shader fragment
@@ -24,5 +24,5 @@ uniform samplerCube skybox;
 
 void main()
 {
-FragColor = texture(skybox, TexCoords);
+    FragColor = texture(skybox, TexCoords);
 }


### PR DESCRIPTION
Skyboxes didn't support textures in GL_RGBA format since the skybox since there is nothing behind the skybox on the scene that should be visible, thus making the alpha component redundant.

Some skybox textures do come in a GL_RGBA format, or even GL_RED and this PR enables support for GL_RED,  GL_RGB, and GL_RGBA out of the box.

No additional changes are needed from the user's perspective of the `ResourcesController::skybox` API.