### PR TITLE
[Style] Introduce identifier naming convention prebuild check

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ The `resources/models/` directory stores all the models. Let's add a backpack mo
 
 ```cpp
     Model* backpack = engine::core::Controller::get<engine::resources::ResourcesController>()->model("backpack");
-    Shader* shader   = ... 
-    backpack->draw(shader);
+Shader* shader   = ...
+backpack->draw(shader);
 ```
 
 ### How to add a texture?
@@ -284,17 +284,17 @@ Here is an example of displaying camera info in a GUI.
 
 ```cpp
     auto graphics = engine::core::Controller::get<engine::graphics::GraphicsController>();
-    graphics->begin_gui();
-    // Draw Camera Info window
-    {
-        ImGui::Begin("Camera info");
-        const auto &c = *camera;
-        ImGui::Text("Camera position: (%f, %f, %f)", c.Position.x, c.Position.y, c.Position.z);
-        ImGui::Text("(Yaw, Pitch): (%f, %f)", c.Yaw, c.Pitch);
-        ImGui::Text("Camera front: (%f, %f, %f)", c.Front.x, c.Front.y, c.Front.z);
-        ImGui::End();
-    }
-    graphics->end_gui();
+graphics->begin_gui();
+// Draw Camera Info window
+{
+ImGui::Begin("Camera info");
+const auto &c = *camera;
+ImGui::Text("Camera position: (%f, %f, %f)", c.Position.x, c.Position.y, c.Position.z);
+ImGui::Text("(Yaw, Pitch): (%f, %f)", c.Yaw, c.Pitch);
+ImGui::Text("Camera front: (%f, %f, %f)", c.Front.x, c.Front.y, c.Front.z);
+ImGui::End();
+}
+graphics->end_gui();
 ```
 
 ![img.png](extra/img.png)
@@ -378,9 +378,9 @@ the `key` on which the event occurred as an argument.
 
 ```cpp
     auto platform = engine::core::Controller::get<engine::platform::PlatformController>();
-    platform->window()->height()
-    platform->window()->width()
-    platform->window()->title()
+platform->window()->height()
+platform->window()->width()
+platform->window()->title()
 ```
 
 Also, the `PlatformController` will update the window properties if the size of the window changes.
@@ -453,8 +453,8 @@ passed as the second argument to the `arg` method.
 ```cpp
 
 void setup() override {
-    auto parser = engine::util::ArgParser()->instance();
-    auto fps = parser->arg<int>("--fps", 60);
+auto parser = engine::util::ArgParser()->instance();
+auto fps = parser->arg<int>("--fps", 60);
 }
 ```
 
@@ -464,3 +464,103 @@ void setup() override {
 
 Here you can find a walkthrough [tutorial](engine/test/app/TUTORIAL.md) for recreating the `engine/test/app` that
 demonstrates how to use different engine systems.
+
+# Style guide
+
+Naming Conventions:
+
+* Global variables: g_ prefix (e.g., g_counter)
+* Namespaces: snake_case (e.g., math_utils)
+* Structs: PascalCase (e.g., Point3D)
+* Classes: PascalCase (e.g., Calculator)
+* Static/constant variables: UPPER_CASE (e.g., MAX_OPERATIONS)
+* Public member variables: snake_case (e.g., is_active)
+* Protected member variables: m_ prefix + snake_case (e.g., m_name)
+* Private member variables: m_ prefix + snake_case (e.g., m_max_size)
+* Member functions: snake_case (e.g., calculate_average)
+* Free functions: snake_case (e.g., process_data)
+* Parameters: snake_case (e.g., max_size)
+* Local variables: snake_case (e.g., initial_capacity)
+* Template parameters: PascalCase (e.g., Container, Result, MaxSize)
+
+Code style:
+
+* Control flow statements (if/for/while/switch/try) always with braces
+* One line per variable declaration, no multiple variable declarations on a single line
+
+```C++
+#include <vector>
+#include <string>
+
+// Global variable with g_ prefix
+int g_counter = 0;
+
+// Namespace in snake_case
+namespace math_utils {
+
+// Struct in PascalCase
+struct Point3D {
+    float x, y, z;
+};
+
+// Class in PascalCase
+class Calculator {
+public:
+    // Static and/or constant in UPPER_CASE
+    static const int MAX_OPERATIONS = 100;
+    
+    // Public member variable in snake_case
+    bool is_active;
+    
+    // Constructor (parameters in snake_case)
+    Calculator(int max_size) : m_max_size(max_size), is_active(true) {
+        // Local variable in snake_case
+        int initial_capacity = max_size * 2;
+        m_results.reserve(initial_capacity);
+    }
+    
+    // Member function in snake_case
+    float calculate_average(const std::vector<float>& values) {
+        // Parameter and local variables in snake_case
+        float sum = 0.0f;
+        int count = 0;
+        
+        // Loop with braces on same line
+        for (const auto& value : values) {
+            sum += value;
+            ++count;
+        }
+        
+        // If statement with braces on same line
+        if (count > 0) {
+            return sum / count;
+        }
+        
+        return 0.0f;
+    }
+
+protected:
+    // Protected member with m_ prefix
+    std::string m_name;
+
+private:
+    // Private member variables with m_ prefix
+    int m_max_size;
+    std::vector<float> m_results;
+};
+
+} // namespace math_utils
+
+// Free function in snake_case
+void process_data() {
+    // Local variable in snake_case
+    math_utils::Calculator calc(50);
+    ++g_counter;
+}
+
+// Template parameters always in PascalCase 
+template<typename Container, typename Result, int MaxSize>
+Result operation(const Container& c) {
+   // . 
+}
+```

--- a/engine/include/engine/graphics/Camera.hpp
+++ b/engine/include/engine/graphics/Camera.hpp
@@ -89,11 +89,6 @@ public:
                     float yaw = YAW, float pitch = PITCH);
 
     /**
-     * @brief  constructor with scalar values.
-     */
-    Camera(float posX, float posY, float posZ, float upX, float upY, float upZ, float yaw, float pitch);
-
-    /**
      * @returns  returns the view matrix calculated using Euler Angles and the LookAt Matrix.
      */
     glm::mat4 view_matrix() const;
@@ -101,12 +96,12 @@ public:
     /**
      * @brief Processes input received from any keyboard-like input system. Accepts input parameter in the form of camera defined ENUM (to abstract it from windowing systems).
      */
-    void move_camera(Movement direction, float deltaTime);
+    void move_camera(Movement direction, float delta_time);
 
     /**
      * @brief Processes input received from a mouse input system. Expects the offset value in both the x and y direction.
      */
-    void rotate_camera(float x_offset, float y_offset, bool constrainPitch = true);
+    void rotate_camera(float x_offset, float y_offset, bool constrain_pitch = true);
 
     /**
      * @brief Processes input received from a mouse scroll-wheel event. Only requires to be input on the vertical wheel-axis

--- a/engine/include/engine/resources/Shader.hpp
+++ b/engine/include/engine/resources/Shader.hpp
@@ -147,7 +147,7 @@ private:
     /**
     * @brief The OpenGL ID of the shader program.
     */
-    unsigned m_shaderId;
+    unsigned m_shader_id;
 
     /**
     * @brief The name of the shader program

--- a/engine/include/engine/util/Utils.hpp
+++ b/engine/include/engine/util/Utils.hpp
@@ -16,14 +16,6 @@
 #include <type_traits>
 
 /// @cond
-template<class... Ts>
-struct overloaded : Ts ... {
-    using Ts::operator()...;
-};
-
-template<class... Ts>
-overloaded(Ts...) -> overloaded<Ts...>;
-
 template<typename Func>
 struct DeferImpl {
     DeferImpl(Func f) : f(f) {

--- a/engine/src/Camera.cpp
+++ b/engine/src/Camera.cpp
@@ -12,24 +12,14 @@ Camera::Camera(glm::vec3 position, glm::vec3 up, float yaw, float pitch) :
     update_camera_vectors();
 }
 
-// constructor with scalar values
-Camera::Camera(float posX, float posY, float posZ, float upX, float upY, float upZ, float yaw, float pitch) :
-        Front(glm::vec3(0.0f, 0.0f, -1.0f)), MovementSpeed(SPEED), MouseSensitivity(SENSITIVITY), Zoom(ZOOM) {
-    Position = glm::vec3(posX, posY, posZ);
-    WorldUp = glm::vec3(upX, upY, upZ);
-    Yaw = yaw;
-    Pitch = pitch;
-    update_camera_vectors();
-}
-
 // returns the view matrix calculated using Euler Angles and the LookAt Matrix
 glm::mat4 Camera::view_matrix() const {
     return glm::lookAt(Position, Position + Front, Up);
 }
 
 // processes input received from any keyboard-like input system. Accepts input parameter in the form of camera defined ENUM (to abstract it from windowing systems)
-void Camera::move_camera(Movement direction, float deltaTime) {
-    float velocity = MovementSpeed * deltaTime;
+void Camera::move_camera(Movement direction, float delta_time) {
+    float velocity = MovementSpeed * delta_time;
     if (direction == FORWARD) {
         Position += Front * velocity;
     }
@@ -51,7 +41,7 @@ void Camera::move_camera(Movement direction, float deltaTime) {
 }
 
 // processes input received from a mouse input system. Expects the offset value in both the x and y direction.
-void Camera::rotate_camera(float x_offset, float y_offset, bool constrainPitch) {
+void Camera::rotate_camera(float x_offset, float y_offset, bool constrain_pitch) {
     x_offset *= MouseSensitivity;
     y_offset *= MouseSensitivity;
 
@@ -59,7 +49,7 @@ void Camera::rotate_camera(float x_offset, float y_offset, bool constrainPitch) 
     Pitch += y_offset;
 
     // make sure that when pitch is out of bounds, screen doesn't get flipped
-    if (constrainPitch) {
+    if (constrain_pitch) {
         if (Pitch > 89.0f) {
             Pitch = 89.0f;
         }

--- a/engine/src/Shader.cpp
+++ b/engine/src/Shader.cpp
@@ -5,64 +5,64 @@
 namespace engine::resources {
 
 void Shader::use() const {
-    glUseProgram(m_shaderId);
+    glUseProgram(m_shader_id);
 }
 
 void Shader::destroy() const {
-    glDeleteProgram(m_shaderId);
+    glDeleteProgram(m_shader_id);
 }
 
 unsigned Shader::id() const {
-    return m_shaderId;
+    return m_shader_id;
 }
 
 void Shader::set_bool(const std::string &name, bool value) const {
-    uint32_t location = CHECKED_GL_CALL(glGetUniformLocation, m_shaderId, name.c_str());
+    uint32_t location = CHECKED_GL_CALL(glGetUniformLocation, m_shader_id, name.c_str());
     CHECKED_GL_CALL(glUniform1i, location, static_cast<int>(value));
 }
 
 void Shader::set_int(const std::string &name, int value) const {
-    uint32_t location = CHECKED_GL_CALL(glGetUniformLocation, m_shaderId, name.c_str());
+    uint32_t location = CHECKED_GL_CALL(glGetUniformLocation, m_shader_id, name.c_str());
     CHECKED_GL_CALL(glUniform1i, location, value);
 }
 
 void Shader::set_float(const std::string &name, float value) const {
-    uint32_t location = CHECKED_GL_CALL(glGetUniformLocation, m_shaderId, name.c_str());
+    uint32_t location = CHECKED_GL_CALL(glGetUniformLocation, m_shader_id, name.c_str());
     CHECKED_GL_CALL(glUniform1f, location, value);
 }
 
 void Shader::set_vec2(const std::string &name, const glm::vec2 &value) const {
-    uint32_t location = CHECKED_GL_CALL(glGetUniformLocation, m_shaderId, name.c_str());
+    uint32_t location = CHECKED_GL_CALL(glGetUniformLocation, m_shader_id, name.c_str());
     CHECKED_GL_CALL(glUniform2fv, location, 1, &value[0]);
 }
 
 void Shader::set_vec3(const std::string &name, const glm::vec3 &value) const {
-    uint32_t location = CHECKED_GL_CALL(glGetUniformLocation, m_shaderId, name.c_str());
+    uint32_t location = CHECKED_GL_CALL(glGetUniformLocation, m_shader_id, name.c_str());
     CHECKED_GL_CALL(glUniform3fv, location, 1, &value[0]);
 }
 
 void Shader::set_vec4(const std::string &name, const glm::vec4 &value) const {
-    uint32_t location = CHECKED_GL_CALL(glGetUniformLocation, m_shaderId, name.c_str());
+    uint32_t location = CHECKED_GL_CALL(glGetUniformLocation, m_shader_id, name.c_str());
     CHECKED_GL_CALL(glUniform4fv, location, 1, &value[0]);
 }
 
 void Shader::set_mat2(const std::string &name, const glm::mat2 &mat) const {
-    uint32_t location = CHECKED_GL_CALL(glGetUniformLocation, m_shaderId, name.c_str());
+    uint32_t location = CHECKED_GL_CALL(glGetUniformLocation, m_shader_id, name.c_str());
     CHECKED_GL_CALL(glUniformMatrix2fv, location, 1, GL_FALSE, &mat[0][0]);
 }
 
 void Shader::set_mat3(const std::string &name, const glm::mat3 &mat) const {
-    uint32_t location = CHECKED_GL_CALL(glGetUniformLocation, m_shaderId, name.c_str());
+    uint32_t location = CHECKED_GL_CALL(glGetUniformLocation, m_shader_id, name.c_str());
     CHECKED_GL_CALL(glUniformMatrix3fv, location, 1, GL_FALSE, &mat[0][0]);
 }
 
 void Shader::set_mat4(const std::string &name, const glm::mat4 &mat) const {
-    uint32_t location = CHECKED_GL_CALL(glGetUniformLocation, m_shaderId, name.c_str());
+    uint32_t location = CHECKED_GL_CALL(glGetUniformLocation, m_shader_id, name.c_str());
     CHECKED_GL_CALL(glUniformMatrix4fv, location, 1, GL_FALSE, &mat[0][0]);
 }
 
 Shader::Shader(unsigned shader_id, std::string name, std::string source, std::filesystem::path source_path) :
-        m_shaderId(shader_id)
+        m_shader_id(shader_id)
         , m_name(std::move(name))
         , m_source(std::move(source))
         , m_source_path(std::move(source_path)) {


### PR DESCRIPTION
This PR enhances the static verification system by introducing a new rule to enforce C++ naming conventions project-wide using libclang. It supplements existing line-based checks with full-source AST-level analysis, enabling structured detection of naming violations.

**Motivation**:
Naming convention enforcement was previously missing, which could lead to inconsistent code. This PR ensures stylistic consistency and improves code maintainability across the project.

Notes:
The style guide can be found in the README.md.